### PR TITLE
Fix TXT record duplication and fix for unclean exit

### DIFF
--- a/bin
+++ b/bin
@@ -27,7 +27,7 @@ _do_updates() {
 		done
 
 		# Sort at the end stabilizes the result, so we can compare it across runs
-		for discovered_node in $(ubus call umdns browse '{ "service": "_rrm_nr._udp", "array": true }' | jsonfilter -e '@["_rrm_nr._udp"][*].txt[*]' | grep "\"${net_ssid}\"" | sed "s/${net_ssid}=//g"); do
+		for discovered_node in $(ubus call umdns browse '{ "service": "_rrm_nr._udp", "array": true }' | jsonfilter -e '@["_rrm_nr._udp"][*].txt[*]' | grep "\"${net_ssid}\"" | sed -E "s/SSID\d+=//g"); do
 			rrm_nr_lists="${rrm_nr_lists}"$'\n'"${discovered_node}"
 		done
 

--- a/bin
+++ b/bin
@@ -51,10 +51,27 @@ _do_updates() {
 	IFS=$OIFS
 }
 
-while true; do
-	_do_updates
+# This is an alternate approach to the original "sleep 60" in the while loop below.
+# The issue with "sleep 60" is that the rrm_nr service will not exit cleanly because
+# by default it only waits up to 5 seconds for this script to exit. But because the while
+# loop is sleeping, it fails to exit cleanly because procd sends a SIGKILL which cannot be
+# trapped.
 
-	sleep 60
+# Set the delay_counter to 20 initially so we immediately execute do_updates upon entering
+# the while loop. Then subsequently set the counter back to 0 and begin incrementing every
+# 3 seconds until we reach 20 iterations again (=60 seconds between do_updates calls).
+# In this way, procd can actually signal a clean exit since this will become responsive again
+# every 3 seconds now.
+delay_counter=20
+while true; do
+	if [ $delay_counter -eq 20 ]; then
+		_do_updates
+		delay_counter=0
+	else
+		delay_counter=$((delay_counter + 1))
+	fi
+
+	sleep 3
 done
 
 exit 0

--- a/initscript
+++ b/initscript
@@ -21,12 +21,14 @@ start_service() {
 	OIFS=$IFS
 	IFS=$'\x0a'
 
+	local ssid_count=1
 	for value in $(ubus list hostapd.*); do
 		curr_value=$(/bin/ubus call "${value}" rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')
 		ssid=$(echo "$curr_value" | awk -F, '{ print $2; }' | sed 's/^ *"//;s/" *$//')
 		# Using + as the delimiter instead of |. Because + is an invalid character to use in SSID naming,
 		# this removes the known issue where | could not be used in the SSID name.
-		rrm_own="${rrm_own}+${ssid}=${curr_value}"
+		rrm_own="${rrm_own}+SSID${ssid_count}=${curr_value}"
+		ssid_count=$((ssid_count + 1))
 	done
 
 	rrm_own="${rrm_own#*+}"

--- a/initscript
+++ b/initscript
@@ -24,7 +24,6 @@ start_service() {
 	local ssid_count=1
 	for value in $(ubus list hostapd.*); do
 		curr_value=$(/bin/ubus call "${value}" rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')
-		ssid=$(echo "$curr_value" | awk -F, '{ print $2; }' | sed 's/^ *"//;s/" *$//')
 		# Using + as the delimiter instead of |. Because + is an invalid character to use in SSID naming,
 		# this removes the known issue where | could not be used in the SSID name.
 		rrm_own="${rrm_own}+SSID${ssid_count}=${curr_value}"


### PR DESCRIPTION
These should be safe changes:

1. Per mDNS standard, avoid duplicate TXT key names by switching to SSID<incrementing #>=[ "<MAC>", "<SSID>", "<NR Information Element>" ]
2. In order to facilitate a clean rrm_nr service exit, the bin script now has an alternate approach to the 60 second refresh whereby instead of sleeping for 60 seconds, it only sleeps for 3 seconds * 20 iterations. This results in a 60 second delay between update checks, but allows the service to end the bin script cleanly without timing out and having to issue a SIGKILL.